### PR TITLE
Require Jenkins 2.479.3 and Jakarta EE 9

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,3 +1,3 @@
-buildPlugin(jdkVersions: [11, 17],
+buildPlugin(jdkVersions: [17, 21],
             spotbugs: [qualityGates: [[threshold: 5, type: 'TOTAL', unstable: true]]]
 )

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>4.82</version>
+        <version>5.18</version>
         <relativePath />
     </parent>
     <groupId>org.jenkins-ci.plugins</groupId>
@@ -17,12 +17,12 @@
     <licenses>
         <license>
             <name>GNU GENERAL PUBLIC LICENSE (GPL-3.0-or-later)</name>
-            <url>http://www.opensource.org/licenses/gpl-3.0.html</url>
+            <url>https://www.opensource.org/licenses/gpl-3.0.html</url>
         </license>
     </licenses>
     <organization>
         <name>Byte-Code</name>
-        <url>http://www.byte-code.com</url>
+        <url>https://www.byte-code.com</url>
     </organization>
     <developers>
         <developer>
@@ -56,7 +56,7 @@
         <changelist>999999-SNAPSHOT</changelist>
         <gitHubRepo>jenkinsci/libvirt-agent-plugin</gitHubRepo>
         <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
-        <jenkins.baseline>2.414</jenkins.baseline>
+        <jenkins.baseline>2.479</jenkins.baseline>
         <jenkins.version>${jenkins.baseline}.3</jenkins.version>
         <spotbugs.effort>Max</spotbugs.effort>
         <spotbugs.failOnError>false</spotbugs.failOnError>
@@ -147,7 +147,7 @@
         <dependency>
             <groupId>io.jenkins.tools.bom</groupId>
             <artifactId>bom-${jenkins.baseline}.x</artifactId>
-            <version>2982.vdce2153031a_0</version>
+            <version>4948.vcf1d17350668</version>
             <scope>import</scope>
             <type>pom</type>
         </dependency>

--- a/src/main/java/hudson/plugins/libvirt/ComputerUtils.java
+++ b/src/main/java/hudson/plugins/libvirt/ComputerUtils.java
@@ -142,7 +142,7 @@ public final class ComputerUtils {
 
     public static void revertToSnapshot(final VirtualMachine virtualMachine, final String snapshotName,
             @CheckForNull final TaskListener listener) {
-        if (snapshotName != null && snapshotName.length() > 0) {
+        if (snapshotName != null && !snapshotName.isEmpty()) {
             final IDomain domain = getDomain(virtualMachine, listener);
             if (domain != null) {
                 try {

--- a/src/main/java/hudson/plugins/libvirt/Hypervisor.java
+++ b/src/main/java/hudson/plugins/libvirt/Hypervisor.java
@@ -47,6 +47,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.logging.Level;
 import java.util.logging.LogRecord;
@@ -58,7 +59,6 @@ import hudson.util.ListBoxModel;
 import java.util.Arrays;
 import jenkins.model.Jenkins;
 import net.sf.json.JSONObject;
-import org.acegisecurity.Authentication;
 import org.apache.commons.lang.StringUtils;
 
 import org.kohsuke.stapler.AncestorInPath;
@@ -66,6 +66,7 @@ import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.StaplerRequest2;
 import org.kohsuke.stapler.verb.POST;
+import org.springframework.security.core.Authentication;
 
 /**
  * Represents a virtual datacenter.
@@ -103,11 +104,7 @@ public class Hypervisor extends Cloud {
         }
         this.hypervisorTransport = hypervisorTransport;
         this.hypervisorHost = hypervisorHost;
-        if (hypervisorSystemUrl != null) {
-            this.hypervisorSystemUrl = hypervisorSystemUrl;
-        } else {
-            this.hypervisorSystemUrl = "system";
-        }
+        this.hypervisorSystemUrl = Objects.requireNonNullElse(hypervisorSystemUrl, "system");
 
         if (hypervisorSshPort > 0) {
             this.hypervisorSshPort = hypervisorSshPort;
@@ -415,9 +412,9 @@ public class Hypervisor extends Cloud {
         }
         return CredentialsMatchers.firstOrNull(
                 CredentialsProvider
-                        .lookupCredentials(StandardUsernamePasswordCredentials.class,
-                                           Jenkins.get(), ACL.SYSTEM,
-                                new SchemeRequirement("ssh")),
+                        .lookupCredentialsInItemGroup(StandardUsernamePasswordCredentials.class,
+                                           Jenkins.get(), ACL.SYSTEM2,
+                                List.of(new SchemeRequirement("ssh"))),
                 CredentialsMatchers.withId(credentialsId)
         );
     }
@@ -487,9 +484,9 @@ public class Hypervisor extends Cloud {
 
             Authentication auth;
             if (context instanceof Queue.Task) {
-                auth = Tasks.getAuthenticationOf((Queue.Task) context);
+                auth = Tasks.getAuthenticationOf2((Queue.Task) context);
             } else {
-                auth = ACL.SYSTEM;
+                auth = ACL.SYSTEM2;
             }
             return model
                     .includeEmptyValue()

--- a/src/main/java/hudson/plugins/libvirt/Hypervisor.java
+++ b/src/main/java/hudson/plugins/libvirt/Hypervisor.java
@@ -52,7 +52,7 @@ import java.util.logging.Level;
 import java.util.logging.LogRecord;
 import java.util.logging.Logger;
 
-import javax.servlet.ServletException;
+import jakarta.servlet.ServletException;
 
 import hudson.util.ListBoxModel;
 import java.util.Arrays;
@@ -64,7 +64,7 @@ import org.apache.commons.lang.StringUtils;
 import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.QueryParameter;
-import org.kohsuke.stapler.StaplerRequest;
+import org.kohsuke.stapler.StaplerRequest2;
 import org.kohsuke.stapler.verb.POST;
 
 /**
@@ -442,7 +442,7 @@ public class Hypervisor extends Cloud {
         }
 
         @Override
-        public boolean configure(StaplerRequest req, JSONObject o)
+        public boolean configure(StaplerRequest2 req, JSONObject o)
                 throws FormException {
             type = o.getString("hypervisorType");
             transport = o.getString("hypervisorTransport");

--- a/src/main/java/hudson/plugins/libvirt/PluginImpl.java
+++ b/src/main/java/hudson/plugins/libvirt/PluginImpl.java
@@ -32,14 +32,14 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import javax.annotation.Nullable;
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletResponse;
 
 import jenkins.model.Jenkins;
 
 import org.kohsuke.stapler.QueryParameter;
-import org.kohsuke.stapler.StaplerRequest;
-import org.kohsuke.stapler.StaplerResponse;
+import org.kohsuke.stapler.StaplerRequest2;
+import org.kohsuke.stapler.StaplerResponse2;
 import org.kohsuke.stapler.verb.POST;
 
 /**
@@ -141,7 +141,7 @@ public class PluginImpl extends Plugin {
         }
     }
 
-    public void doComputerNameValues(StaplerRequest req, StaplerResponse rsp,
+    public void doComputerNameValues(StaplerRequest2 req, StaplerResponse2 rsp,
                                      @QueryParameter("value") String value)
             throws IOException, ServletException {
         ListBoxModel m = new ListBoxModel();
@@ -169,7 +169,7 @@ public class PluginImpl extends Plugin {
         m.writeTo(req, rsp);
     }
 
-    public void doSnapshotNameValues(StaplerRequest req, StaplerResponse rsp,
+    public void doSnapshotNameValues(StaplerRequest2 req, StaplerResponse2 rsp,
                                      @QueryParameter("vm") String vm,
                                      @QueryParameter("hypervisor") String hypervisor)
             throws IOException, ServletException {

--- a/src/main/java/hudson/plugins/libvirt/PluginImpl.java
+++ b/src/main/java/hudson/plugins/libvirt/PluginImpl.java
@@ -153,8 +153,7 @@ public class PluginImpl extends Plugin {
         }
 
         for (Cloud cloud : Jenkins.get().clouds) {
-            if (cloud instanceof Hypervisor) {
-                Hypervisor hypervisor = (Hypervisor) cloud;
+            if (cloud instanceof Hypervisor hypervisor) {
                 if (value != null && value.equals(hypervisor.getHypervisorDescription())) {
                     virtualMachines = hypervisor.getVirtualMachines();
                     break;
@@ -182,8 +181,7 @@ public class PluginImpl extends Plugin {
 
         m.add(new ListBoxModel.Option("", ""));
         for (Cloud cloud : Jenkins.get().clouds) {
-            if (cloud instanceof Hypervisor) {
-                Hypervisor hypHandle = (Hypervisor) cloud;
+            if (cloud instanceof Hypervisor hypHandle) {
                 if (hypervisor != null && hypervisor.equals(hypHandle.getHypervisorURI())) {
                     String[] ss = hypHandle.getSnapshots(vm);
                     for (String sshot : ss) {

--- a/src/main/java/hudson/plugins/libvirt/VirtualMachine.java
+++ b/src/main/java/hudson/plugins/libvirt/VirtualMachine.java
@@ -45,11 +45,9 @@ public class VirtualMachine implements Comparable<VirtualMachine> {
         if (this == o) {
             return true;
         }
-        if (!(o instanceof VirtualMachine)) {
+        if (!(o instanceof VirtualMachine that)) {
             return false;
         }
-
-        VirtualMachine that = (VirtualMachine) o;
 
         if (hypervisor == null) {
             if (that.hypervisor != null) {
@@ -62,16 +60,10 @@ public class VirtualMachine implements Comparable<VirtualMachine> {
         }
 
         if (name == null) {
-            if (that.name != null) {
-                return false;
-            }
+            return that.name == null;
         } else {
-            if (!name.equals(that.name)) {
-                return false;
-            }
+            return name.equals(that.name);
         }
-
-        return true;
     }
 
     @Override

--- a/src/main/java/hudson/plugins/libvirt/VirtualMachineManagementServer.java
+++ b/src/main/java/hudson/plugins/libvirt/VirtualMachineManagementServer.java
@@ -10,16 +10,16 @@ import hudson.plugins.libvirt.lib.VirtException;
 import jenkins.model.Jenkins;
 
 import org.kohsuke.stapler.QueryParameter;
-import org.kohsuke.stapler.StaplerRequest;
-import org.kohsuke.stapler.StaplerResponse;
+import org.kohsuke.stapler.StaplerRequest2;
+import org.kohsuke.stapler.StaplerResponse2;
 import org.kohsuke.stapler.verb.POST;
 
-import javax.servlet.ServletException;
+import jakarta.servlet.ServletException;
 
 import java.io.IOException;
 import java.util.Collection;
 import java.util.Date;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpServletResponse;
 
 /**
  * @author Nigel Magnay
@@ -59,7 +59,7 @@ public class VirtualMachineManagementServer implements Describable<VirtualMachin
     }
 
     @POST
-    public void doControlSubmit(@QueryParameter("stopId") String stopId, StaplerRequest req, StaplerResponse rsp) throws ServletException,
+    public void doControlSubmit(@QueryParameter("stopId") String stopId, StaplerRequest2 req, StaplerResponse2 rsp) throws ServletException,
             IOException,
             InterruptedException, VirtException {
 

--- a/src/main/java/hudson/plugins/libvirt/VirtualMachineSlave.java
+++ b/src/main/java/hudson/plugins/libvirt/VirtualMachineSlave.java
@@ -37,6 +37,7 @@ import hudson.util.ListBoxModel;
 import jenkins.model.Jenkins;
 
 import java.io.IOException;
+import java.io.Serial;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -51,7 +52,8 @@ import org.kohsuke.stapler.DataBoundConstructor;
  */
 public class VirtualMachineSlave extends Slave {
 
-    static final long serialVersionUID = 1L;
+    @Serial
+    private static final long serialVersionUID = 1L;
     private static final Logger LOGGER = Logger.getLogger(VirtualMachineSlave.class.getName());
 
     private final String      hypervisorDescription;

--- a/src/main/java/hudson/plugins/libvirt/lib/libvirt/LibvirtConnectAuth.java
+++ b/src/main/java/hudson/plugins/libvirt/lib/libvirt/LibvirtConnectAuth.java
@@ -42,12 +42,12 @@ public final class LibvirtConnectAuth extends ConnectAuth {
                 default:
                     // ignore
             }
-            if (response.equals("") && (c.defresult == null || !c.defresult.equals(""))) {
+            if (response.isEmpty() && (c.defresult == null || !c.defresult.isEmpty())) {
                 c.result = c.defresult;
             } else {
                 c.result = response;
             }
-            if (c.result == null || c.result.equals("")) {
+            if (c.result == null || c.result.isEmpty()) {
                 return -1;
             }
         }

--- a/src/main/resources/hudson/plugins/libvirt/VirtualMachineLauncher/main.jelly
+++ b/src/main/resources/hudson/plugins/libvirt/VirtualMachineLauncher/main.jelly
@@ -26,7 +26,7 @@ THE SOFTWARE.
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
   <j:choose>
     <j:when test="${!it.launchSupported and it.offline and !it.temporarilyOffline}">
-      <j:set var="jenkinsURL" value="${h.inferHudsonURL(request)}"/>
+      <j:set var="jenkinsURL" value="${h.inferHudsonURL(request2)}"/>
       <j:set var="copy_agent_jar_unix" value="curl -sO ${jenkinsURL}jnlpJars/agent.jar" />
       <j:set var="copy_agent_jar_windows" value="curl.exe -sO ${jenkinsURL}jnlpJars/agent.jar" />
       <j:set var="copy_java_cmd_unix" value="java -jar agent.jar -url ${jenkinsURL} ${it.launcher.launcher.getRemotingOptionsUnix(it)}${it.launcher.launcher.getWorkDirOptions(it)}" />


### PR DESCRIPTION
## Require Jenkins 2.479.3 and Jakarta EE 9

Jenkins 2.479.3 provides Jakarta EE 9, Eclipse Jetty 12, Spring Security 6, and Java 17.

* Update plugin pom and baseline
* Remove deprecations
* Use Java 17 language features
* Minor cleanup

### Testing done

`mvn clean verify`

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed